### PR TITLE
Feature/#51

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,6 @@ FROM alpine:3.9.4
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /main .
 
-CMD ./main --host 0.0.0.0 --port 8080
+CMD ./main --host 0.0.0.0 --port ${PORT}
 
-EXPOSE 8080
+EXPOSE ${PORT}

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bin/web
+web: bin/backend

--- a/backend/main.go
+++ b/backend/main.go
@@ -6,12 +6,13 @@ package main
 
 import (
 	"net/http"
-	//"os"
+	"os"
 
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
 	"github.com/mock-mock/mockmock-meter/backend/command"
 	"github.com/mock-mock/mockmock-meter/backend/domain"
+	"github.com/mock-mock/mockmock-meter/backend/utils"
 
 	dao "github.com/mock-mock/mockmock-meter/backend/dao"
 )
@@ -79,7 +80,9 @@ func main() {
 	})
 
 	// サーバー起動
-	//e.Start(":8080")
-	//e.Logger.Fatal(e.Start(":" + os.Getenv("PORT")))
-	e.Logger.Fatal(e.Start(":8080"))
+	port := os.Getenv("PORT")
+	if utils.StringIsEmpty(port) {
+		port = "8080"
+	}
+	e.Logger.Fatal(e.Start(":" + port))
 }

--- a/backend/utils/string.go
+++ b/backend/utils/string.go
@@ -1,0 +1,7 @@
+package utils
+
+// check string is empty or not
+// -- true when empty
+func StringIsEmpty(str string) bool {
+	return str == ""
+}


### PR DESCRIPTION
## Issue番号
- #51 

## やったこと
- echoサーバが任意の環境変数にて渡されたPORTにて起動するよう変更
- Dockerコンテナも任意のPORTで起動するよう変更

## 達成した内容の確認方法
- docker build -t mockmock-server .
- docker run --name mockmock -d -e "PORT=8888" -p 8888:8888 -t mockmock-server //port指定あり
- docker run --name mockmock -d -p 8080:8080 -t mockmock-server //port指定なし
- curl localhost:8888/api // returns "Hello!"

## その他 (不要なら削除して良い)
- 特になし

